### PR TITLE
Migrate to LTS-12.26

### DIFF
--- a/servant-util-beam-pg/package.yaml
+++ b/servant-util-beam-pg/package.yaml
@@ -11,7 +11,6 @@ dependencies:
 - servant
 - servant-client
 - servant-client-core
-- servant-generic
 - servant-server
 - servant-util >= 0.1.0 && < 0.2
 - text

--- a/servant-util-beam-pg/src/Servant/Util/Beam/Postgres/Sorting.hs
+++ b/servant-util-beam-pg/src/Servant/Util/Beam/Postgres/Sorting.hs
@@ -8,8 +8,7 @@ module Servant.Util.Beam.Postgres.Sorting
 import Universum
 
 import Data.Coerce (coerce)
-import Database.Beam.Backend.SQL.SQL92 (IsSql92OrderingSyntax, Sql92OrderingExpressionSyntax,
-                                        Sql92SelectExpressionSyntax, Sql92SelectOrderingSyntax)
+import Database.Beam.Backend.SQL (BeamSqlBackend)
 import Database.Beam.Query (SqlOrderable, asc_, desc_, orderBy_)
 import Database.Beam.Query.Internal (Projectible, Q, QExpr, QNested, QOrd, ThreadRewritable,
                                      WithRewrittenThread)
@@ -20,11 +19,11 @@ import Servant.Util.Combinators.Sorting.Base
 -- | Implements sorting for beam-postgres package.
 data BeamSortingBackend syntax s
 
-instance IsSql92OrderingSyntax syntax =>
+instance BeamSqlBackend syntax =>
          SortingBackend (BeamSortingBackend syntax s) where
 
     type SortedValue (BeamSortingBackend syntax s) a =
-        QExpr (Sql92OrderingExpressionSyntax syntax) s a
+        QExpr syntax s a
 
     type BackendOrdering (BeamSortingBackend syntax s) =
         QOrd syntax s Void
@@ -45,10 +44,10 @@ instance IsSql92OrderingSyntax syntax =>
 
 -- | Applies 'orderBy_' according to the given sorting specification.
 sortBy_
-    :: ( backend ~ BeamSortingBackend syntax0 s0
+    :: ( backend ~ BeamSortingBackend syntax s
        , ApplyToSortItem backend params
-       , Projectible (Sql92SelectExpressionSyntax syntax) a
-       , SqlOrderable (Sql92SelectOrderingSyntax syntax) (BackendOrdering backend)
+       , Projectible syntax a
+       , SqlOrderable syntax (BackendOrdering backend)
        , ThreadRewritable (QNested s) a
        )
     => SortingSpec params

--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -20,7 +20,6 @@ dependencies:
 - servant
 - servant-client
 - servant-client-core
-- servant-generic
 - servant-server
 - servant-swagger
 - servant-swagger-ui

--- a/servant-util/src/Servant/Util/Combinators/ErrorResponses.hs
+++ b/servant-util/src/Servant/Util/Combinators/ErrorResponses.hs
@@ -14,7 +14,7 @@ import Servant.Swagger (HasSwagger (..))
 import Servant ((:>), HasServer (..))
 import Servant.Client (HasClient (..))
 import GHC.TypeLits (Symbol, KnownSymbol)
-import Data.Kind (type (*))
+import Data.Kind (Type)
 import qualified Data.Swagger as S
 import Data.Swagger.Declare (runDeclare)
 
@@ -25,7 +25,7 @@ import Servant.Util.Common
 -- | Type-level information about an error response.
 data ErrorDesc = ErrorDesc
     { erCode :: Nat
-    , erException :: *
+    , erException :: Type
     , erDesc :: Symbol
     }
 
@@ -81,6 +81,7 @@ instance HasServer subApi ctx => HasServer (ErrorResponses errors :> subApi) ctx
 instance HasClient m subApi => HasClient m (ErrorResponses errors :> subApi) where
     type Client m (ErrorResponses errors :> subApi) = Client m subApi
     clientWithRoute pm _ = clientWithRoute pm (Proxy @subApi)
+    hoistClientMonad pm _ = hoistClientMonad pm (Proxy @subApi)
 
 instance HasLoggingServer config subApi ctx =>
          HasLoggingServer config (ErrorResponses errors :> subApi) ctx where

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Backend.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Backend.hs
@@ -17,14 +17,14 @@ module Servant.Util.Combinators.Filtering.Backend
     , manualFilter
     ) where
 
-import Universum
+import           Universum
 
-import Data.Kind (type (*))
-import Data.Typeable (gcast1)
-import GHC.TypeLits (KnownSymbol)
+import           Data.Kind                               (Type)
+import           Data.Typeable                           (gcast1)
+import           GHC.TypeLits                            (KnownSymbol)
 
-import Servant.Util.Combinators.Filtering.Base
-import Servant.Util.Common
+import           Servant.Util.Combinators.Filtering.Base
+import           Servant.Util.Common
 
 -- | Implementation of filtering backend.
 class FilterBackend backend where
@@ -67,13 +67,13 @@ type FilteringSpecApp backend params =
 
 -- | Force a type family to be defined.
 -- Primarily for prettier error messages.
-type family AreFiltersDefined (a :: [* -> *]) :: Constraint where
+type family AreFiltersDefined (a :: [Type -> Type]) :: Constraint where
     AreFiltersDefined '[] = Show (Int -> Int)
     AreFiltersDefined a = ()
 
 -- | Lookup among filters supported for this type and prepare
 -- an appropriate one for (deferred) application.
-class TypeAutoFiltersSupport' backend (filters :: [* -> *]) a where
+class TypeAutoFiltersSupport' backend (filters :: [Type -> Type]) a where
     typeAutoFiltersSupport' :: SomeTypeAutoFilter a -> Maybe (AutoFilterImpl backend a)
 
 instance TypeAutoFiltersSupport' backend '[] a where
@@ -108,7 +108,7 @@ typeAutoFiltersSupport filtr =
     ?: error "impossible, invariants of SomeTypeFilter are violated"
 
 -- | Apply a filter for a specific type, evaluate whether a value matches or not.
-class BackendApplyTypeFilter backend (fk :: * -> FilterKind *) a where
+class BackendApplyTypeFilter backend (fk :: Type -> FilterKind Type) a where
     backendApplyTypeFilter
         :: FilteringApp backend ('TyNamedParam name (fk a))
         -> TypeFilter fk a

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
@@ -54,3 +54,6 @@ instance (HasClient m subApi, SomeFilterToReq params) =>
         FilteringSpec params -> Client m subApi
     clientWithRoute mp _ req (FilteringSpec filters) =
         clientWithRoute mp (Proxy @subApi) (foldr someFilterToReq req filters)
+
+    hoistClientMonad mp _ nat clientOld spec =
+        hoistClientMonad mp (Proxy @subApi) nat $ clientOld spec

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
@@ -11,7 +11,7 @@ import Universum
 
 import qualified Data.Map as M
 import qualified Data.Text.Lazy as LT
-import Fmt (build, (+|), (|+))
+import Fmt (Buildable, build, (+|), (|+))
 import Servant (ToHttpApiData (..), FromHttpApiData (..))
 import System.Console.Pretty (Color (..), Style (..), color, style)
 

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Server.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Server.hs
@@ -5,20 +5,23 @@ module Servant.Util.Combinators.Filtering.Server
     ( AreFilteringParams
     ) where
 
-import Universum
+import           Universum
 
-import Data.Kind (type (*))
-import qualified Data.Map as M
-import qualified Data.Text as T
-import Fmt (Buildable (..))
-import GHC.TypeLits (KnownSymbol)
-import Network.HTTP.Types.URI (QueryText, parseQueryText)
-import Network.Wai.Internal (rawQueryString)
-import Servant ((:>), FromHttpApiData (..), HasServer (..), ServantErr (..), err400)
-import Servant.Server.Internal (addParameterCheck, delayedFailFatal, withRequest)
+import           Data.Kind                               (Type)
+import qualified Data.Map                                as M
+import qualified Data.Text                               as T
+import           Fmt                                     (Buildable (..))
+import           GHC.TypeLits                            (KnownSymbol)
+import           Network.HTTP.Types.URI                  (QueryText, parseQueryText)
+import           Network.Wai.Internal                    (rawQueryString)
+import           Servant                                 ((:>), FromHttpApiData (..),
+                                                          HasServer (..), ServantErr (..),
+                                                          err400)
+import           Servant.Server.Internal                 (addParameterCheck,
+                                                          delayedFailFatal, withRequest)
 
-import Servant.Util.Combinators.Filtering.Base
-import Servant.Util.Common
+import           Servant.Util.Combinators.Filtering.Base
+import           Servant.Util.Common
 
 -- | Try to parse query key assuming that the specified field to filter on
 -- should match the given name.
@@ -37,7 +40,7 @@ parseQueryKey field key = do
 -- If the parameter is not recognized as filtering one, 'Nothing' is returned.
 -- Otherwise it is parsed and any potential errors are reported as-is.
 parseAutoTypeFilteringParam
-    :: forall a (filters :: [* -> *]).
+    :: forall a (filters :: [Type -> Type]).
        (filters ~ SupportedFilters a, AreAutoFilters filters, FromHttpApiData a)
     => Text -> Text -> Text -> Maybe (Either Text $ SomeTypeAutoFilter a)
 parseAutoTypeFilteringParam field key val = do

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Swagger.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Swagger.hs
@@ -3,19 +3,19 @@
 
 module Servant.Util.Combinators.Filtering.Swagger () where
 
-import Universum
+import           Universum
 
-import Control.Lens ((<>~))
-import Data.Kind (type (*))
-import qualified Data.Swagger as S
-import qualified Data.Text as T
-import GHC.TypeLits (KnownSymbol)
-import Servant.API ((:>))
-import Servant.Swagger (HasSwagger (..))
+import           Control.Lens                            ((<>~))
+import           Data.Kind                               (Type)
+import qualified Data.Swagger                            as S
+import qualified Data.Text                               as T
+import           GHC.TypeLits                            (KnownSymbol)
+import           Servant.API                             ((:>))
+import           Servant.Swagger                         (HasSwagger (..))
 
-import Servant.Util.Combinators.Filtering.Base
-import Servant.Util.Common
-import Servant.Util.Swagger
+import           Servant.Util.Combinators.Filtering.Base
+import           Servant.Util.Common
+import           Servant.Util.Swagger
 
 -- | Make a 'S.Param' for a filtering query parameter.
 filterSwaggerParam :: forall a. S.ToParamSchema a => Text -> Text -> S.Param
@@ -64,7 +64,7 @@ manualFilterDesc =
     "Leave values matching given parameter " <> parenValueDesc @a <> "."
 
 -- | Gather swagger params for all of the given filters.
-class AutoFiltersOpsDesc (filters :: [* -> *]) where
+class AutoFiltersOpsDesc (filters :: [Type -> Type]) where
     autoFiltersOpsDesc :: OpsDescriptions
 
 instance AutoFiltersOpsDesc '[] where
@@ -80,7 +80,7 @@ instance ( IsAutoFilter filter
         ]
 
 -- | Get documentation for the given filter kind.
-class FilterKindHasSwagger (fk :: FilterKind *) where
+class FilterKindHasSwagger (fk :: FilterKind Type) where
     filterKindSwagger :: Text -> S.Param
 
 instance DescribedParam a => FilterKindHasSwagger ('ManualFilter a) where

--- a/servant-util/src/Servant/Util/Combinators/Pagination.hs
+++ b/servant-util/src/Servant/Util/Combinators/Pagination.hs
@@ -104,6 +104,8 @@ instance HasClient m subApi =>
         clientWithRoute mp (Proxy @(PaginationParamsExpanded subApi)) req
             (guard (psOffset > 0) $> psOffset)
             psLimit
+    hoistClientMonad mp _ nat clientOld spec =
+        hoistClientMonad mp (Proxy @subApi) nat $ clientOld spec
 
 instance HasSwagger api => HasSwagger (PaginationParams :> api) where
     toSwagger _ = toSwagger (Proxy @api)

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
@@ -16,9 +16,13 @@ instance HasClient m subApi =>
          HasClient m (SortingParams params :> subApi) where
     type Client m (SortingParams params :> subApi) =
         SortingSpec params -> Client m subApi
+
     clientWithRoute mp _ req (SortingSpec sorting) =
         clientWithRoute mp (Proxy @(SortParamsExpanded params subApi)) req
             (Just $ Tagged sorting)
+
+    hoistClientMonad mp _ nat clientOld spec =
+        hoistClientMonad mp (Proxy @subApi) nat $ clientOld spec
 
 instance ToHttpApiData (TaggedSortingItemsList allowed) where
     toUrlPiece (Tagged sorting) =

--- a/servant-util/src/Servant/Util/Combinators/Tag.hs
+++ b/servant-util/src/Servant/Util/Combinators/Tag.hs
@@ -29,6 +29,7 @@ instance HasServer subApi ctx => HasServer (Tag name :> subApi) ctx where
 instance HasClient m subApi => HasClient m (Tag name :> subApi) where
     type Client m (Tag name :> subApi) = Client m subApi
     clientWithRoute pm _ = clientWithRoute pm (Proxy @subApi)
+    hoistClientMonad pm _ = hoistClientMonad pm (Proxy @subApi)
 
 instance HasLoggingServer config subApi ctx =>
          HasLoggingServer config (Tag name :> subApi) ctx where
@@ -69,6 +70,7 @@ instance HasServer subApi ctx => HasServer (TagDescriptions ver mapping :> subAp
 instance HasClient m subApi => HasClient m (TagDescriptions ver mapping :> subApi) where
     type Client m (TagDescriptions ver mapping :> subApi) = Client m subApi
     clientWithRoute pm _ = clientWithRoute pm (Proxy @subApi)
+    hoistClientMonad pm _ = hoistClientMonad pm (Proxy @subApi)
 
 instance HasLoggingServer config subApi ctx =>
          HasLoggingServer config (TagDescriptions ver mapping :> subApi) ctx where

--- a/servant-util/src/Servant/Util/Common/Common.hs
+++ b/servant-util/src/Servant/Util/Common/Common.hs
@@ -18,6 +18,8 @@ import Servant.API ((:>), Capture, QueryFlag, QueryParam', ReqBody)
 import Servant.Server (Handler (..), HasServer (..), Server)
 import qualified Servant.Server.Internal as SI
 
+import Servant.Util.Internal.Util (pretty)
+
 type family ApplicationLS x where
     ApplicationLS (a b) = a
 

--- a/servant-util/src/Servant/Util/Internal/Util.hs
+++ b/servant-util/src/Servant/Util/Internal/Util.hs
@@ -5,10 +5,15 @@ module Servant.Util.Internal.Util
     , IsNotZero
     , KnownPositive
     , positiveVal
+    , prettyL
+    , pretty
     ) where
 
 import Universum
 
+import Data.Text.Lazy (toStrict)
+import Data.Text.Lazy.Builder (toLazyText)
+import Fmt (Buildable (..))
 import GHC.TypeLits (ErrorMessage (..), KnownNat, Nat, TypeError)
 import Servant (FromHttpApiData (..), ToHttpApiData (..))
 
@@ -34,3 +39,9 @@ instance (FromHttpApiData a, Show a, Ord a, Num a) => FromHttpApiData (Positive 
 
 instance ToHttpApiData a => ToHttpApiData (Positive a) where
     toUrlPiece = toUrlPiece @a . unPositive
+
+prettyL :: Buildable a => a -> LText
+prettyL = toLazyText . build
+
+pretty :: Buildable a => a -> Text
+pretty = toStrict . prettyL

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,16 @@
-resolver: lts-11.17
+resolver: lts-12.26
 
 packages:
 - servant-util
 - servant-util-beam-pg
 
 extra-deps:
-- beam-postgres-0.3.2.2
+- beam-core-0.8.0.0
+- beam-postgres-0.4.0.0
+- beam-migrate-0.4.0.1
 - pretty-terminal-0.1.0.0
-- universum-1.1.0
+- fmt-0.6.1.1
+- text-format-0.3.2
 
 nix:
   packages: [zlib, postgresql]


### PR DESCRIPTION
This became necessary due to intended usage of the library in the
scope of Agora project. The changes are mostly due to the updates in `servant`, `universum` and `beam-core`.

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
