### PR TITLE
Bump to LTS-14.16

### DIFF
--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -12,6 +12,7 @@ dependencies:
 - data-default
 - fmt
 - http-types
+- insert-ordered-containers
 - lens
 - megaparsec
 - mtl
@@ -20,10 +21,10 @@ dependencies:
 - servant
 - servant-client
 - servant-client-core
-- servant-generic
 - servant-server
 - servant-swagger
 - servant-swagger-ui
+- servant-swagger-ui-core
 - swagger2
 - text
 - text-format

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Backend.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Backend.hs
@@ -19,7 +19,7 @@ module Servant.Util.Combinators.Filtering.Backend
 
 import Universum
 
-import Data.Kind (type (*))
+import Data.Kind (Type)
 import Data.Typeable (gcast1)
 import GHC.TypeLits (KnownSymbol)
 
@@ -67,13 +67,13 @@ type FilteringSpecApp backend params =
 
 -- | Force a type family to be defined.
 -- Primarily for prettier error messages.
-type family AreFiltersDefined (a :: [* -> *]) :: Constraint where
+type family AreFiltersDefined (a :: [Type -> Type]) :: Constraint where
     AreFiltersDefined '[] = Show (Int -> Int)
     AreFiltersDefined a = ()
 
 -- | Lookup among filters supported for this type and prepare
 -- an appropriate one for (deferred) application.
-class TypeAutoFiltersSupport' backend (filters :: [* -> *]) a where
+class TypeAutoFiltersSupport' backend (filters :: [Type -> Type]) a where
     typeAutoFiltersSupport' :: SomeTypeAutoFilter a -> Maybe (AutoFilterImpl backend a)
 
 instance TypeAutoFiltersSupport' backend '[] a where
@@ -108,7 +108,7 @@ typeAutoFiltersSupport filtr =
     ?: error "impossible, invariants of SomeTypeFilter are violated"
 
 -- | Apply a filter for a specific type, evaluate whether a value matches or not.
-class BackendApplyTypeFilter backend (fk :: * -> FilterKind *) a where
+class BackendApplyTypeFilter backend (fk :: Type -> FilterKind Type) a where
     backendApplyTypeFilter
         :: FilteringApp backend ('TyNamedParam name (fk a))
         -> TypeFilter fk a

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
@@ -8,7 +8,7 @@ import Data.Typeable (cast)
 import GHC.TypeLits (KnownSymbol)
 import Servant ((:>), ToHttpApiData (..), toQueryParam)
 import Servant.Client (HasClient (..))
-import Servant.Client.Core.Internal.Request (Request, appendToQueryString)
+import Servant.Client.Core.Request (Request, appendToQueryString)
 
 import Servant.Util.Combinators.Filtering.Base
 import Servant.Util.Combinators.Filtering.Support ()
@@ -54,3 +54,4 @@ instance (HasClient m subApi, SomeFilterToReq params) =>
         FilteringSpec params -> Client m subApi
     clientWithRoute mp _ req (FilteringSpec filters) =
         clientWithRoute mp (Proxy @subApi) (foldr someFilterToReq req filters)
+    hoistClientMonad pm _ hst subCli = hoistClientMonad pm (Proxy @subApi) hst . subCli

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
@@ -11,7 +11,7 @@ import Universum
 
 import qualified Data.Map as M
 import qualified Data.Text.Lazy as LT
-import Fmt (build, (+|), (|+))
+import Fmt (Buildable (..), (+|), (|+))
 import Servant (ToHttpApiData (..), FromHttpApiData (..))
 import System.Console.Pretty (Color (..), Style (..), color, style)
 

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Server.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Server.hs
@@ -7,14 +7,14 @@ module Servant.Util.Combinators.Filtering.Server
 
 import Universum
 
-import Data.Kind (type (*))
+import Data.Kind (Type)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Fmt (Buildable (..))
 import GHC.TypeLits (KnownSymbol)
 import Network.HTTP.Types.URI (QueryText, parseQueryText)
 import Network.Wai.Internal (rawQueryString)
-import Servant ((:>), FromHttpApiData (..), HasServer (..), ServantErr (..), err400)
+import Servant ((:>), FromHttpApiData (..), HasServer (..), ServerError (..), err400)
 import Servant.Server.Internal (addParameterCheck, delayedFailFatal, withRequest)
 
 import Servant.Util.Combinators.Filtering.Base
@@ -37,7 +37,7 @@ parseQueryKey field key = do
 -- If the parameter is not recognized as filtering one, 'Nothing' is returned.
 -- Otherwise it is parsed and any potential errors are reported as-is.
 parseAutoTypeFilteringParam
-    :: forall a (filters :: [* -> *]).
+    :: forall a (filters :: [Type -> Type]).
        (filters ~ SupportedFilters a, AreAutoFilters filters, FromHttpApiData a)
     => Text -> Text -> Text -> Maybe (Either Text $ SomeTypeAutoFilter a)
 parseAutoTypeFilteringParam field key val = do

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Swagger.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Swagger.hs
@@ -6,7 +6,7 @@ module Servant.Util.Combinators.Filtering.Swagger () where
 import Universum
 
 import Control.Lens ((<>~))
-import Data.Kind (type (*))
+import Data.Kind (Type)
 import qualified Data.Swagger as S
 import qualified Data.Text as T
 import GHC.TypeLits (KnownSymbol)
@@ -64,7 +64,7 @@ manualFilterDesc =
     "Leave values matching given parameter " <> parenValueDesc @a <> "."
 
 -- | Gather swagger params for all of the given filters.
-class AutoFiltersOpsDesc (filters :: [* -> *]) where
+class AutoFiltersOpsDesc (filters :: [Type -> Type]) where
     autoFiltersOpsDesc :: OpsDescriptions
 
 instance AutoFiltersOpsDesc '[] where
@@ -80,7 +80,7 @@ instance ( IsAutoFilter filter
         ]
 
 -- | Get documentation for the given filter kind.
-class FilterKindHasSwagger (fk :: FilterKind *) where
+class FilterKindHasSwagger (fk :: FilterKind Type) where
     filterKindSwagger :: Text -> S.Param
 
 instance DescribedParam a => FilterKindHasSwagger ('ManualFilter a) where

--- a/servant-util/src/Servant/Util/Combinators/Pagination.hs
+++ b/servant-util/src/Servant/Util/Combinators/Pagination.hs
@@ -105,6 +105,8 @@ instance HasClient m subApi =>
             (guard (psOffset > 0) $> psOffset)
             psLimit
 
+    hoistClientMonad pm _ hst subCli = hoistClientMonad pm (Proxy @subApi) hst . subCli
+
 instance HasSwagger api => HasSwagger (PaginationParams :> api) where
     toSwagger _ = toSwagger (Proxy @api)
         & S.allOperations . S.parameters <>~ [S.Inline offsetParam, S.Inline limitParam]
@@ -121,7 +123,7 @@ instance HasSwagger api => HasSwagger (PaginationParams :> api) where
                 & S.paramSchema .~ offsetParamSchema
                 )
         offsetParamSchema = mempty
-            & S.type_ .~ S.SwaggerInteger
+            & S.type_ ?~ S.SwaggerInteger
             & S.format ?~ "int32"
 
         limitParam = mempty
@@ -133,5 +135,5 @@ instance HasSwagger api => HasSwagger (PaginationParams :> api) where
                 & S.paramSchema .~ limitParamSchema
                 )
         limitParamSchema = mempty
-            & S.type_ .~ S.SwaggerInteger
+            & S.type_ ?~ S.SwaggerInteger
             & S.format ?~ "int32"

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
@@ -19,6 +19,7 @@ instance HasClient m subApi =>
     clientWithRoute mp _ req (SortingSpec sorting) =
         clientWithRoute mp (Proxy @(SortParamsExpanded params subApi)) req
             (Just $ Tagged sorting)
+    hoistClientMonad mp _ hst subCli = hoistClientMonad mp (Proxy @subApi) hst . subCli
 
 instance ToHttpApiData (TaggedSortingItemsList allowed) where
     toUrlPiece (Tagged sorting) =

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
@@ -44,7 +44,7 @@ instance ( HasServer subApi ctx
 instance ReifyParamsNames allowed =>
          FromHttpApiData (TaggedSortingItemsList allowed) where
     parseUrlPiece =
-        first (toText . P.parseErrorPretty) . second Tagged .
+        first (toText . P.errorBundlePretty) . second Tagged .
         P.parse parser "sortBy"
       where
         parser = do

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Swagger.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Swagger.hs
@@ -35,7 +35,7 @@ instance (HasSwagger api, ReifyParamsNames params) =>
                 & S.paramSchema .~ paramSchema
                 )
         paramSchema = mempty
-            & S.type_ .~ S.SwaggerString
+            & S.type_ ?~ S.SwaggerString
             & S.pattern ?~ "^" <> fieldPattern <> "(," <> fieldPattern <> ")*" <> "$"
         fieldPattern =
             "(" <> "[+-](" <> allowedFieldsPattern <> ")+" <> "|" <>

--- a/servant-util/src/Servant/Util/Combinators/Tag.hs
+++ b/servant-util/src/Servant/Util/Combinators/Tag.hs
@@ -41,7 +41,7 @@ instance (HasSwagger subApi, KnownSymbol name) =>
       where
         name = symbolValT @name
 
--- | Whether to enable some type-level checks for 'Tag's and 'TagsVerification'
+-- | Whether to enable some type-level checks for 'Tag's and 'TagsDescription's
 -- correspondence.
 --
 -- Note that with the current implementation of 'S.Swagger' datatype your tags

--- a/servant-util/src/Servant/Util/Combinators/Tag.hs
+++ b/servant-util/src/Servant/Util/Combinators/Tag.hs
@@ -7,7 +7,7 @@ module Servant.Util.Combinators.Tag
 import Universum
 
 import Control.Lens (at, (?~))
-import qualified Data.Set as S
+import qualified Data.HashSet.InsOrd as HS
 import qualified Data.Swagger as S
 import GHC.TypeLits (ErrorMessage (..), KnownSymbol, Symbol, TypeError)
 import Servant ((:<|>), (:>), HasServer (..), StdMethod, Verb)
@@ -29,10 +29,11 @@ instance HasServer subApi ctx => HasServer (Tag name :> subApi) ctx where
 instance HasClient m subApi => HasClient m (Tag name :> subApi) where
     type Client m (Tag name :> subApi) = Client m subApi
     clientWithRoute pm _ = clientWithRoute pm (Proxy @subApi)
+    hoistClientMonad pm _ hst = hoistClientMonad pm (Proxy @subApi) hst
 
 instance HasLoggingServer config subApi ctx =>
          HasLoggingServer config (Tag name :> subApi) ctx where
-    routeWithLog = inRouteServer @(Tag name :> LoggingApiRec config subApi) route identity
+    routeWithLog = inRouteServer @(Tag name :> LoggingApiRec config subApi) route id
 
 instance (HasSwagger subApi, KnownSymbol name) =>
          HasSwagger (Tag name :> subApi) where
@@ -43,10 +44,6 @@ instance (HasSwagger subApi, KnownSymbol name) =>
 
 -- | Whether to enable some type-level checks for 'Tag's and 'TagsDescription's
 -- correspondence.
---
--- Note that with the current implementation of 'S.Swagger' datatype your tags
--- (and thus endpoints) will be sorted alphabetically in UI, relevant ticket:
--- https://github.com/GetShopTV/swagger2/issues/165.
 data TagsVerification
     = -- | Ensure that mappings are specified exactly for those tags which
       -- appear in API.
@@ -69,12 +66,13 @@ instance HasServer subApi ctx => HasServer (TagDescriptions ver mapping :> subAp
 instance HasClient m subApi => HasClient m (TagDescriptions ver mapping :> subApi) where
     type Client m (TagDescriptions ver mapping :> subApi) = Client m subApi
     clientWithRoute pm _ = clientWithRoute pm (Proxy @subApi)
+    hoistClientMonad pm _ hst = hoistClientMonad pm (Proxy @subApi) hst
 
 instance HasLoggingServer config subApi ctx =>
          HasLoggingServer config (TagDescriptions ver mapping :> subApi) ctx where
     routeWithLog =
         inRouteServer @(TagDescriptions ver mapping :> LoggingApiRec config subApi)
-        route identity
+        route id
 
 -- | Gather all tag names used in API. Result may contain duplicates.
 type family AllApiTags api :: [Symbol] where
@@ -86,7 +84,7 @@ type family AllApiTags api :: [Symbol] where
 
 -- | Extract tags defined by this mapping.
 class ReifyTagsFromMapping (mapping :: [TyNamedParam Symbol]) where
-    reifyTagsFromMapping :: Set S.Tag
+    reifyTagsFromMapping :: HS.InsOrdHashSet S.Tag
 
 instance ReifyTagsFromMapping '[] where
     reifyTagsFromMapping = mempty
@@ -101,7 +99,7 @@ instance ( KnownSymbol name, KnownSymbol desc
         { S._tagName = symbolValT @name
         , S._tagDescription = Just $ symbolValT @desc
         , S._tagExternalDocs = Nothing
-        } `S.insert` reifyTagsFromMapping @mapping
+        } `HS.insert` reifyTagsFromMapping @mapping
 
 instance ( HasSwagger api
          , ReifyTagsFromMapping mapping

--- a/servant-util/src/Servant/Util/Common/Common.hs
+++ b/servant-util/src/Servant/Util/Common/Common.hs
@@ -13,6 +13,7 @@ module Servant.Util.Common.Common
 import Universum
 
 import qualified Data.Text.Buildable as B
+import Fmt (pretty)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Servant.API ((:>), Capture, QueryFlag, QueryParam', ReqBody)
 import Servant.Server (Handler (..), HasServer (..), Server)
@@ -40,7 +41,7 @@ class ApiHasArgClass api where
         :: forall n someApiType a. (KnownSymbol n, api ~ someApiType n a)
         => Proxy api -> String
     apiArgName _ =
-        toString . pretty $ "'" <> B.build (symbolVal $ Proxy @n) <> "' field"
+        pretty $ "'" <> B.build (symbolVal $ Proxy @n) <> "' field"
 
 class ServerT (subApi :> res) m ~ (ApiArg subApi -> ServerT res m)
    => ApiHasArgInvariant subApi res m
@@ -58,7 +59,7 @@ instance KnownSymbol s => ApiHasArgClass (QueryParam' mods s a) where
 instance KnownSymbol s => ApiHasArgClass (QueryFlag s) where
     type ApiArg (QueryFlag s) = Bool
     apiArgName _ =
-        toString . pretty $ "'" <> B.build (symbolVal (Proxy @s)) <>  "' flag"
+        pretty $ "'" <> B.build (symbolVal (Proxy @s)) <>  "' flag"
 instance ApiHasArgClass (ReqBody ct a) where
     apiArgName _ = "request body"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,11 @@
-resolver: lts-11.17
+resolver: lts-14.16
 
 packages:
 - servant-util
 - servant-util-beam-pg
 
 extra-deps:
-- beam-postgres-0.3.2.2
 - pretty-terminal-0.1.0.0
-- universum-1.1.0
 
 nix:
   packages: [zlib, postgresql]


### PR DESCRIPTION
Use recent LTS for the sake of Agora.

Please test whether Agora works as expected with these changes before merging them since Beam dependency has been bumped as well.   

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
