### PR TITLE
Avoid instance overlap in HasLoggingServer

### DIFF
--- a/servant-util/src/Servant/Util/Combinators/Logging.hs
+++ b/servant-util/src/Servant/Util/Combinators/Logging.hs
@@ -226,7 +226,7 @@ instance ( HasServer (subApi :> res) ctx
          , ApiHasArg subApi (LoggingApiRec config res)
          , ApiCanLogArg subApi
          , Buildable (ApiArgToLog subApi)
-         , subApi ~ apiType a
+         , subApi ~ apiType (a :: Type)
          ) =>
          HasLoggingServer config (apiType a :> res) ctx where
     routeWithLog = paramRouteWithLog


### PR DESCRIPTION
The instance for `subApi :> ...` was overlapping with all other instances for `... :> ...` due to the kind being more polymorphic than it needed to be.

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
