### PR TITLE
Add cabal files to resolve build issues with stack>=2.1.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-*.cabal

--- a/servant-util-beam-pg/servant-util-beam-pg.cabal
+++ b/servant-util-beam-pg/servant-util-beam-pg.cabal
@@ -1,0 +1,107 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.32.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: b1942928d7676d20d3c050c371200a0440a2444e01dc2331d26cb6afff8dc7ed
+
+name:           servant-util-beam-pg
+version:        0.1.0
+synopsis:       Primitives implementation via beam-postgres.
+description:    Please see the README on GitHub at <https://github.com/serokell/servant-util#README.md>
+category:       Web
+homepage:       https://github.com/serokell/servant-util#readme
+bug-reports:    https://github.com/serokell/servant-util/issues
+author:         Serokell
+maintainer:     hi@serokell.io
+copyright:      2019 Serokell OÜ
+license:        MPL-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGES.md
+
+source-repository head
+  type: git
+  location: https://github.com/serokell/servant-util
+
+library
+  exposed-modules:
+      Servant.Util.Beam.Postgres
+      Servant.Util.Beam.Postgres.Filtering
+      Servant.Util.Beam.Postgres.Pagination
+      Servant.Util.Beam.Postgres.Sorting
+  other-modules:
+      Paths_servant_util_beam_pg
+  hs-source-dirs:
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror
+  build-tool-depends:
+      autoexporter:autoexporter
+  build-depends:
+      base >=4.7 && <5
+    , beam-core
+    , beam-postgres
+    , containers
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-util >=0.1.0 && <0.2
+    , text
+    , universum
+  default-language: Haskell2010
+
+executable servant-util-beam-pg-examples
+  main-is: Main.hs
+  other-modules:
+      Paths_servant_util_beam_pg
+  hs-source-dirs:
+      examples
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -O2
+  build-depends:
+      base >=4.7 && <5
+    , beam-core
+    , beam-postgres
+    , containers
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-util >=0.1.0 && <0.2
+    , text
+    , universum
+  default-language: Haskell2010
+
+test-suite servant-util-beam-pg-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Spec
+      Tests.Servant.Filtering.LikeSpec
+      Paths_servant_util_beam_pg
+  hs-source-dirs:
+      tests
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      QuickCheck
+    , base >=4.7 && <5
+    , beam-core
+    , beam-postgres
+    , containers
+    , hspec
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-util >=0.1.0 && <0.2
+    , servant-util-beam-pg
+    , text
+    , universum
+  default-language: Haskell2010

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -1,0 +1,195 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.32.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: ab46cb5854651a3232ba1d54bebd825187509925fa4d2478d46a8afa7ae4beeb
+
+name:           servant-util
+version:        0.1.0
+synopsis:       Servant servers utilities.
+description:    Please see the README on GitHub at <https://github.com/serokell/servant-util#README.md>
+category:       Web
+homepage:       https://github.com/serokell/servant-util#readme
+bug-reports:    https://github.com/serokell/servant-util/issues
+author:         Serokell
+maintainer:     hi@serokell.io
+copyright:      2019 Serokell OÜ
+license:        MPL-2.0
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGES.md
+
+source-repository head
+  type: git
+  location: https://github.com/serokell/servant-util
+
+library
+  exposed-modules:
+      Servant.Util
+      Servant.Util.Combinators
+      Servant.Util.Combinators.ErrorResponses
+      Servant.Util.Combinators.Filtering
+      Servant.Util.Combinators.Filtering.Backend
+      Servant.Util.Combinators.Filtering.Base
+      Servant.Util.Combinators.Filtering.Client
+      Servant.Util.Combinators.Filtering.Construction
+      Servant.Util.Combinators.Filtering.Filters
+      Servant.Util.Combinators.Filtering.Filters.General
+      Servant.Util.Combinators.Filtering.Filters.Like
+      Servant.Util.Combinators.Filtering.Getters
+      Servant.Util.Combinators.Filtering.Logging
+      Servant.Util.Combinators.Filtering.Server
+      Servant.Util.Combinators.Filtering.Support
+      Servant.Util.Combinators.Filtering.Swagger
+      Servant.Util.Combinators.Logging
+      Servant.Util.Combinators.Pagination
+      Servant.Util.Combinators.Sorting
+      Servant.Util.Combinators.Sorting.Arbitrary
+      Servant.Util.Combinators.Sorting.Backend
+      Servant.Util.Combinators.Sorting.Base
+      Servant.Util.Combinators.Sorting.Client
+      Servant.Util.Combinators.Sorting.Construction
+      Servant.Util.Combinators.Sorting.Logging
+      Servant.Util.Combinators.Sorting.Server
+      Servant.Util.Combinators.Sorting.Swagger
+      Servant.Util.Combinators.Tag
+      Servant.Util.Common
+      Servant.Util.Common.Common
+      Servant.Util.Common.HList
+      Servant.Util.Common.PolyKinds
+      Servant.Util.Dummy
+      Servant.Util.Dummy.Filtering
+      Servant.Util.Dummy.Pagination
+      Servant.Util.Dummy.Sorting
+      Servant.Util.Error
+      Servant.Util.Internal.Util
+      Servant.Util.Stats
+      Servant.Util.Swagger
+  other-modules:
+      Paths_servant_util
+  hs-source-dirs:
+      src
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror
+  build-tool-depends:
+      autoexporter:autoexporter
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , containers
+    , data-default
+    , fmt
+    , http-types
+    , insert-ordered-containers
+    , lens
+    , megaparsec
+    , mtl
+    , pretty-terminal
+    , reflection
+    , safe-exceptions
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-swagger
+    , servant-swagger-ui
+    , servant-swagger-ui-core
+    , swagger2
+    , text
+    , text-format
+    , time
+    , universum
+    , wai
+  default-language: Haskell2010
+
+executable servant-util-examples
+  main-is: Main.hs
+  other-modules:
+      Books
+      Paths_servant_util
+  hs-source-dirs:
+      examples
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -O2
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , containers
+    , data-default
+    , fmt
+    , http-types
+    , insert-ordered-containers
+    , lens
+    , megaparsec
+    , mtl
+    , pretty-terminal
+    , reflection
+    , safe-exceptions
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-swagger
+    , servant-swagger-ui
+    , servant-swagger-ui-core
+    , servant-util
+    , swagger2
+    , text
+    , text-format
+    , time
+    , universum
+    , wai
+    , wai-extra
+    , warp
+  default-language: Haskell2010
+
+test-suite servant-util-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Spec
+      Test.Servant.Filtering.GeneralSpec
+      Test.Servant.Filtering.LikeSpec
+      Paths_servant_util
+  hs-source-dirs:
+      tests
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , containers
+    , data-default
+    , fmt
+    , hspec
+    , http-types
+    , insert-ordered-containers
+    , lens
+    , megaparsec
+    , mtl
+    , pretty-terminal
+    , reflection
+    , safe-exceptions
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server
+    , servant-swagger
+    , servant-swagger-ui
+    , servant-swagger-ui-core
+    , servant-util
+    , swagger2
+    , text
+    , text-format
+    , time
+    , universum
+    , wai
+  default-language: Haskell2010


### PR DESCRIPTION
## :white_check_mark: Checklist for your Pull Request

It is a known fact that Stack, starting from versions 2.1.*, cannot into imported hpack configuration files for Git-fetched extra deps: https://github.com/commercialhaskell/stack/issues/4906

Even better, this issue is a `wontfix`, so Stack is not even expected to support this anymore in later versions.

As `servant-util` is widely used throughout Serokell projects, mostly as a git-fetched extra dep, this prevents newer stack versions to be able to build lots of Serokell projects.

We can resolve this just by using older versions of stack throughout the company, but frankly it is better to just include `.cabal` files in this repo.