### PR TITLE
Add `HasLoggingServer` instance for `NoContentVerb`

### DIFF
--- a/servant-util/src/Servant/Util/Combinators/Logging.hs
+++ b/servant-util/src/Servant/Util/Combinators/Logging.hs
@@ -27,7 +27,7 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Fmt (Buildable (..), Builder, blockListF, pretty, (+|), (|+), (||+))
 import GHC.IO.Unsafe (unsafePerformIO)
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import Servant.API (Capture, Description, NoContent, QueryFlag, QueryParam', Raw,
+import Servant.API (Capture, Description, NoContent, NoContentVerb, QueryFlag, QueryParam', Raw,
                     ReflectMethod (..), ReqBody, SBoolI, Summary, Verb, (:<|>) (..), (:>))
 import Servant.API.Modifiers (FoldRequired, foldRequiredArgument)
 import Servant.Server (Handler (..), HasServer (..), Server, ServerError (..))
@@ -382,6 +382,15 @@ instance ( HasServer (Verb mt st ct a) ctx
          HasLoggingServer config (Verb (mt :: k) (st :: Nat) (ct :: [Type]) a) ctx where
     routeWithLog =
         inRouteServer @(Verb mt st ct a) route $
+        applyLoggingToHandler (Proxy @config) (Proxy @mt)
+
+instance ( HasServer (NoContentVerb mt) ctx
+         , Reifies config ServantLogConfig
+         , ReflectMethod mt
+         ) =>
+         HasLoggingServer config (NoContentVerb (mt :: k)) ctx where
+    routeWithLog =
+        inRouteServer @(NoContentVerb mt) route $
         applyLoggingToHandler (Proxy @config) (Proxy @mt)
 
 instance HasLoggingServer config Raw ctx where


### PR DESCRIPTION
Problem: `HasLoggingServer` instance is defined for servant's Verb.
Servant also has NoContentVerb as a separate data type that can be
used in APIs to denote absence of content. Sadly, there is no
`HasLoggingServer` for it, so it's impossible to use
`serverWithLogging` for APIs with `NoContentVerb`.

Solution: define this instance the same way as for `Verb`.

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [ ] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

I didn't add tests because I couldn't find any tests for logging and I don't want to write them from scratch when I make such a small patch.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
