### PR TITLE
Export `Positive` type publically

### DIFF
--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b81f202226a85e97248110a316124552ae47833339db4b64b69b407ecfa3fac2
+-- hash: 3467d7474252809bd865b1d18f4068fc820d199c8f645e0e46b1deb97ddcb1cd
 
 name:           servant-util
 version:        0.1.0
@@ -68,6 +68,7 @@ library
       Servant.Util.Internal.Util
       Servant.Util.Stats
       Servant.Util.Swagger
+      Servant.Util.Util
   other-modules:
       Paths_servant_util
   hs-source-dirs:

--- a/servant-util/src/Servant/Util/Internal/Util.hs
+++ b/servant-util/src/Servant/Util/Internal/Util.hs
@@ -2,6 +2,8 @@
 
 module Servant.Util.Internal.Util
     ( Positive (..)
+    , toPositive
+    , unsafeToPositive
     , IsNotZero
     , KnownPositive
     , positiveVal
@@ -18,7 +20,10 @@ newtype Positive a = PositiveUnsafe { unPositive :: a }
 toPositive :: (Show a, Ord a, Num a) => a -> Either Text (Positive a)
 toPositive a
     | a > 0 = Right $ PositiveUnsafe a
-    | otherwise = Left $ "Value is negative: " <> show a
+    | otherwise = Left $ "Non-positive value: " <> show a
+
+unsafeToPositive :: (Show a, Ord a, Num a, HasCallStack) => a -> Positive a
+unsafeToPositive = either error id . toPositive
 
 type family IsNotZero (k :: Nat) :: Constraint where
     IsNotZero 0 = TypeError ('Text "Null is now allowed here")

--- a/servant-util/src/Servant/Util/Util.hs
+++ b/servant-util/src/Servant/Util/Util.hs
@@ -1,0 +1,9 @@
+-- | Some common utilities.
+module Servant.Util.Util
+    ( Positive (..)
+    , toPositive
+    , unsafeToPositive
+    , positiveVal
+    ) where
+
+import Servant.Util.Internal.Util


### PR DESCRIPTION
Problem: constructing `PaginationSpec` requires a way to construct
`Positive`, but this is not possible without using methods from `Util`
module which is internal.

The original reason for making this module internal was that many
libraries and projects may define their custom `Positive` type, and I
wanted to prevent the users on relying on API of this type since we
have our own purposes on it.

However, users may need to construct values of `Positive` type
themselves and/or define some instances, so it must be exported
publically.

Solution: add public `Util` module, re-export `Positive` type and
constructors there.

Also groom the methods around `Positive` type.

Resolves #18.

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
