### PR TITLE
Add base sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .stack-work/
+stack.yaml.lock
 cabal.project.local
 cabal.project.local~
 .HTF/

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -34,6 +34,7 @@ _definitions:
         - NamedFieldPuns
         - NoImplicitPrelude
         - OverloadedStrings
+        - OverloadedLabels
         - PatternSynonyms
         - RankNTypes
         - RecordWildCards

--- a/servant-util-beam-pg/servant-util-beam-pg.cabal
+++ b/servant-util-beam-pg/servant-util-beam-pg.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ec293a5cfa774a1befb478abd254f939120035078dd87ac1d540f4cea4cc77b5
+-- hash: 6e414f7df673694daf39f7971d2cf2fddd339c132dfab9c1fd3eb6368c796b22
 
 name:           servant-util-beam-pg
 version:        0.1.0
@@ -36,7 +36,7 @@ library
       Paths_servant_util_beam_pg
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror
   build-tool-depends:
       autoexporter:autoexporter
@@ -60,7 +60,7 @@ executable servant-util-beam-pg-examples
       Paths_servant_util_beam_pg
   hs-source-dirs:
       examples
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -O2
   build-depends:
       base >=4.7 && <5
@@ -85,7 +85,7 @@ test-suite servant-util-beam-pg-test
       Paths_servant_util_beam_pg
   hs-source-dirs:
       tests
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover

--- a/servant-util-beam-pg/src/Servant/Util/Beam/Postgres/Sorting.hs
+++ b/servant-util-beam-pg/src/Servant/Util/Beam/Postgres/Sorting.hs
@@ -45,13 +45,14 @@ instance (BeamSqlBackend be) =>
 -- | Applies 'orderBy_' according to the given sorting specification.
 sortBy_
     :: ( backend ~ BeamSortingBackend syntax0 s0
-       , ApplyToSortItem backend params
+       , allParams ~ AllSortingParams provided base
+       , ApplyToSortItem backend allParams
        , Projectible be a
        , SqlOrderable be (BackendOrdering backend)
        , ThreadRewritable (QNested s) a
        )
-    => SortingSpec params
-    -> (a -> SortingSpecApp backend params)
+    => SortingSpec provided base
+    -> (a -> SortingSpecApp backend allParams)
     -> Q be db (QNested s) a
     -> Q be db s (WithRewrittenThread (QNested s) s a)
 sortBy_ spec app = orderBy_ (backendApplySorting spec . app)

--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -60,7 +60,10 @@ tests:
     build-tools: hspec-discover:hspec-discover
     dependencies:
       - hspec
+      - hspec-expectations
+      - http-client
       - servant-util
       - QuickCheck
+      - warp
 
 <<: *default-extensions

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3467d7474252809bd865b1d18f4068fc820d199c8f645e0e46b1deb97ddcb1cd
+-- hash: cd99f8788a70219cab03b6fdc5389e8d71731e9faf921a46971ce32352df7f5c
 
 name:           servant-util
 version:        0.1.0
@@ -73,7 +73,7 @@ library
       Paths_servant_util
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror
   build-tool-depends:
       autoexporter:autoexporter
@@ -114,7 +114,7 @@ executable servant-util-examples
       Paths_servant_util
   hs-source-dirs:
       examples
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N -O2
   build-depends:
       QuickCheck
@@ -156,10 +156,12 @@ test-suite servant-util-test
       Spec
       Test.Servant.Filtering.GeneralSpec
       Test.Servant.Filtering.LikeSpec
+      Test.Servant.Helpers
+      Test.Servant.Sorting.ImplSpec
       Paths_servant_util
   hs-source-dirs:
       tests
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover
@@ -171,6 +173,8 @@ test-suite servant-util-test
     , data-default
     , fmt
     , hspec
+    , hspec-expectations
+    , http-client
     , http-types
     , insert-ordered-containers
     , lens
@@ -193,4 +197,5 @@ test-suite servant-util-test
     , time
     , universum
     , wai
+    , warp
   default-language: Haskell2010

--- a/servant-util/src/Servant/Util/Combinators/Sorting.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting.hs
@@ -3,9 +3,11 @@ module Servant.Util.Combinators.Sorting
     ( -- * General
       SortingParams
     , SortingSpec
+    , SortingOrderType (..)
 
       -- * Shortcuts
-    , SortingParamTypesOf
+    , SortingParamProvidedOf
+    , SortingParamBaseOf
     , SortingParamsOf
     , SortingSpecOf
 
@@ -14,6 +16,7 @@ module Servant.Util.Combinators.Sorting
     , asc, desc
     , mkSortingSpec
     , noSorting
+    , ReifySortingItems
 
       -- * Re-exports
     , type (?:)

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Arbitrary.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Arbitrary.hs
@@ -14,11 +14,12 @@ import Servant.Util.Common
 instance Arbitrary SortingOrder where
     arbitrary = elements [Ascendant, Descendant]
 
-instance ReifyParamsNames params => Arbitrary (SortingSpec params) where
+instance (ReifySortingItems base, ReifyParamsNames provided) =>
+         Arbitrary (SortingSpec provided base) where
     arbitrary = do
-        let names = toList $ reifyParamsNames @params
+        let names = toList $ reifyParamsNames @provided
         someNames <- sublistOf =<< shuffle names
         orders <- infiniteList
         let sortItems = zipWith SortingItem someNames orders
         return (SortingSpec sortItems)
-    shrink = map SortingSpec . reverse . inits . unSortingSpec
+    shrink SortingSpec{..} = map SortingSpec . reverse $ inits ssProvided

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Base.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Base.hs
@@ -2,39 +2,73 @@ module Servant.Util.Combinators.Sorting.Base
     ( SortingParams
     , SortParamsExpanded
     , SortingSpec (..)
+    , ssBase
+    , ssAll
     , SortingOrder (..)
     , NullsSortingOrder (..)
     , SortingItemTagged (..)
     , SortingItem (..)
     , TaggedSortingItemsList
-    , SortingParamTypesOf
+    , SortingOrderType (..)
+    , ReifySortingItems (..)
+    , BaseSortingToParam
+    , AllSortingParams
+    , SortingParamProvidedOf
+    , SortingParamBaseOf
     , SortingParamsOf
     , SortingSpecOf
     ) where
 
 import Universum
 
+import Data.List (nubBy)
 import Fmt (Buildable (..))
+import GHC.TypeLits (KnownSymbol)
 import Servant (QueryParam, (:>))
 import Servant.Server (Tagged (..))
 import Servant.Util.Common
+import qualified Text.Show
 
 {- | Servant API combinator which allows to accept sorting parameters as a query parameter.
 
 Example: with the following combinator
 
 @
-SortingParams ["time" ?: Timestamp, "name" ?: Text]
+SortingParams ["time" ?: Timestamp, "name" ?: Text] '[]
 @
 
 the endpoint can parse "sortBy=-time,+name" or "sortBy=desc(time),asc(name)" formats,
 which would mean sorting by mentioned fields lexicographically. All sorting
 subparameters are optional, as well as entire "sortBy" parameter.
 
+The second type-level list stands for the base sorting order, it will be applied
+in the end disregard the user's input.
+It is highly recommended to specify the base sorting that unambigously orders the
+result(for example - by the primary key of the database), otherwise pagination
+may behave unexpectedly for the client when it specifies no sorting.
+
+If you want the base sorting order to be overridable by the user, you can
+put the respective fields in both lists. For example, this combinator:
+
+@
+SortingParams
+  '["time" ?: Timestamp]
+   ["id" ?: '(Id, 'Descendant), "time" ?: '(Timestamp, 'Ascendant)]
+@
+
+will sort results lexicographically by @(Down id, time)@, but if the client
+specifies sorting by time, you will get sorting by @(time, Down id)@ as the
+trailing @"time"@ will not affect anything.
+
+It is preferred to put a base sorting at least by @ID@, this way results will be
+more deterministic.
+
 Your handler will be provided with 'SortingSpec' argument which can later be passed
 in an appropriate function to perform sorting.
 -}
-data SortingParams (allowed :: [TyNamedParam *])
+data SortingParams
+  (provided :: [TyNamedParam *])
+  (base :: [TyNamedParam (SortingOrderType *)])
 
 -- | How servant sees 'SortParams' under the hood.
 type SortParamsExpanded allowed subApi =
@@ -70,7 +104,7 @@ data SortingItem = SortingItem
 -- | Version 'SortingItem' which remembers its name and parameter type at type level.
 -- In functions which belong to public API you will most probably want to use this datatype
 -- as a safer variant of 'SortingItem'.
-newtype SortingItemTagged (param :: TyNamedParam *) = SortingItemTagged
+newtype SortingItemTagged (provided :: TyNamedParam *) = SortingItemTagged
     { untagSortingItem :: SortingItem
     } deriving (Show)
 
@@ -83,7 +117,14 @@ deriving instance Buildable (SortingItemTagged param)
 
 -- | Tagged, because we want to retain list of allowed fields for parsing
 -- (in @instance FromHttpApiData@).
-type TaggedSortingItemsList allowed = Tagged (allowed :: [TyNamedParam *]) [SortingItem]
+type TaggedSortingItemsList provided = Tagged (provided :: [TyNamedParam *]) [SortingItem]
+
+-- | Order of sorting for type-level.
+--
+-- Its constructors accept the type of thing we order by, e.g. @Asc Id@.
+data SortingOrderType k
+    = Desc k
+    | Asc k
 
 -- | What is passed to an endpoint, contains all sorting parameters provided by a user.
 {- Following properties hold:
@@ -92,19 +133,87 @@ type TaggedSortingItemsList allowed = Tagged (allowed :: [TyNamedParam *]) [Sort
 list with name "N" will be present in @params@.
 
 Not all parameters specified by @params@ phantom type can be present, e.g. the underlying
-list will be empty if user didn't pass "sortBy" query parameter at all.
+list will be empty if user didn't pass "sortBy" query parameter at all. However,
+entries from the base sorting are always present.
 -}
-newtype SortingSpec (params :: [TyNamedParam *]) = SortingSpec
-    { unSortingSpec :: [SortingItem]
-    } deriving (Show)
+data SortingSpec
+  (provided :: [TyNamedParam *])
+  (base :: [TyNamedParam (SortingOrderType *)]) =
+    ReifySortingItems base =>
+    SortingSpec
+    { ssProvided :: [SortingItem]
+      -- ^ Sorting items provided by the user (lexicographical order).
+    }
 
--- | For a given return type of an endpoint get corresponding sorting params.
+instance Show (SortingSpec provided base) where
+    show s =
+        "SortingSpec {ssProvided = " <> show (ssProvided s) <>
+                   ", ssBase = " <> show (ssBase s) <> "}"
+
+-- | Base sorting items, that are present disregard the client's input
+-- (lexicographical order).
+--
+-- This is a sort of virtual field, so such naming.
+ssBase :: forall base provided. SortingSpec provided base -> [SortingItem]
+ssBase SortingSpec{} = reifySortingItems @base
+
+-- | Requires given type-level items to be valid specification of sorting.
+class ReifySortingItems (items :: [TyNamedParam (SortingOrderType *)]) where
+    reifySortingItems :: [SortingItem]
+
+instance ReifySortingItems '[] where
+    reifySortingItems = []
+
+instance ( ReifySortingOrder order, KnownSymbol name
+         , ReifySortingItems items
+         ) => ReifySortingItems ('TyNamedParam name (order field) ': items) where
+    reifySortingItems =
+        SortingItem
+        { siName = symbolValT @name
+        , siOrder = reifySortingOrder @order
+        } : reifySortingItems @items
+
+class ReifySortingOrder (order :: * -> SortingOrderType *) where
+    reifySortingOrder :: SortingOrder
+
+instance ReifySortingOrder 'Asc where
+    reifySortingOrder = Ascendant
+
+instance ReifySortingOrder 'Desc where
+    reifySortingOrder = Descendant
+
+-- | All sorting items with duplicates removed (lexicographical order).
+ssAll :: SortingSpec provided base -> [SortingItem]
+ssAll s = nubBy ((==) `on` siName) (ssProvided s <> ssBase s)
+
+-- | Maps @base@ params to the form common for @provided@ and @base@.
+type family BaseSortingToParam (base :: [TyNamedParam (SortingOrderType *)])
+  :: [TyNamedParam *] where
+    BaseSortingToParam '[] = '[]
+    BaseSortingToParam ('TyNamedParam name (order field) ': xs) =
+      'TyNamedParam name field ': BaseSortingToParam xs
+
+-- | All sorting params, provided + base.
+--
+-- This does not yet remove duplicates from @provided@ and @base@ sets,
+-- we wait for specific use cases to decide how to handle this better.
+type family AllSortingParams
+  (provided :: [TyNamedParam *])
+  (base :: [TyNamedParam (SortingOrderType *)])
+  :: [TyNamedParam *] where
+    AllSortingParams provided base = provided ++ BaseSortingToParam base
+
+-- | For a given return type of an endpoint get corresponding sorting params
+-- that can be specified by user.
 -- This mapping is sensible, since we usually allow to sort only on fields appearing in
 -- endpoint's response.
-type family SortingParamTypesOf a :: [TyNamedParam *]
+type family SortingParamProvidedOf a :: [TyNamedParam *]
+
+-- | For a given return type of an endpoint get corresponding base sorting params.
+type family SortingParamBaseOf a :: [TyNamedParam (SortingOrderType *)]
 
 -- | This you will most probably want to specify in API.
-type SortingParamsOf a = SortingParams (SortingParamTypesOf a)
+type SortingParamsOf a = SortingParams (SortingParamProvidedOf a) (SortingParamBaseOf a)
 
 -- | This you will most probably want to specify in an endpoint implementation.
-type SortingSpecOf a = SortingSpec (SortingParamTypesOf a)
+type SortingSpecOf a = SortingSpec (SortingParamProvidedOf a) (SortingParamBaseOf a)

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Client.hs
@@ -13,15 +13,15 @@ import Servant.Util.Combinators.Sorting.Base
 
 
 instance HasClient m subApi =>
-         HasClient m (SortingParams params :> subApi) where
-    type Client m (SortingParams params :> subApi) =
-        SortingSpec params -> Client m subApi
+         HasClient m (SortingParams provided base :> subApi) where
+    type Client m (SortingParams provided base :> subApi) =
+        SortingSpec provided base -> Client m subApi
     clientWithRoute mp _ req (SortingSpec sorting) =
-        clientWithRoute mp (Proxy @(SortParamsExpanded params subApi)) req
+        clientWithRoute mp (Proxy @(SortParamsExpanded provided subApi)) req
             (Just $ Tagged sorting)
     hoistClientMonad mp _ hst subCli = hoistClientMonad mp (Proxy @subApi) hst . subCli
 
-instance ToHttpApiData (TaggedSortingItemsList allowed) where
+instance ToHttpApiData (TaggedSortingItemsList provided) where
     toUrlPiece (Tagged sorting) =
         T.intercalate "," $ sorting <&> \SortingItem{..} ->
              let order = case siOrder of

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Logging.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Logging.hs
@@ -17,14 +17,15 @@ import Servant.Util.Common
 
 instance ( HasLoggingServer config subApi ctx
          , HasContextEntry (ctx .++ DefaultErrorFormatters) ErrorFormatters
-         , ReifyParamsNames params
+         , ReifySortingItems base
+         , ReifyParamsNames provided
          ) =>
-         HasLoggingServer config (SortingParams params :> subApi) ctx where
+         HasLoggingServer config (SortingParams provided base :> subApi) ctx where
     routeWithLog =
-        inRouteServer @(SortingParams params :> LoggingApiRec config subApi) route $
-        \(paramsInfo, handler) sorting@(SortingSpec params) ->
+        inRouteServer @(SortingParams provided base :> LoggingApiRec config subApi) route $
+        \(paramsInfo, handler) sorting@(SortingSpec provided) ->
             let paramLog
-                  | null params = "no sorting"
+                  | null provided = "no sorting"
                   | otherwise = fmt . mconcat $
-                                "sorting: " : L.intersperse " " (map build params)
+                                "sorting: " : L.intersperse " " (map build provided)
             in (addParamLogInfo paramLog paramsInfo, handler sorting)

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
@@ -19,7 +19,7 @@ import Servant.Util.Combinators.Sorting.Base
 import Servant.Util.Common
 
 
--- | Ensure no name in entires repeat.
+-- | Ensure no name in entries repeat.
 sortingCheckDuplicates :: [SortingItem] -> Either Text ()
 sortingCheckDuplicates items =
     let names = map siName items
@@ -29,14 +29,15 @@ sortingCheckDuplicates items =
 -- | Consumes "sortBy" query parameter and fetches sorting parameters contained in it.
 instance ( HasServer subApi ctx
          , HasContextEntry (ctx .++ DefaultErrorFormatters) ErrorFormatters
-         , ReifyParamsNames params
+         , ReifySortingItems base
+         , ReifyParamsNames provided
          ) =>
-         HasServer (SortingParams params :> subApi) ctx where
-    type ServerT (SortingParams params :> subApi) m =
-        SortingSpec params -> ServerT subApi m
+         HasServer (SortingParams provided base :> subApi) ctx where
+    type ServerT (SortingParams provided base :> subApi) m =
+        SortingSpec provided base -> ServerT subApi m
 
     route =
-        inRouteServer @(SortParamsExpanded params subApi) route $
+        inRouteServer @(SortParamsExpanded provided subApi) route $
         \handler rawSortItems -> handler (SortingSpec $ fmap unTagged rawSortItems ?: [])
 
     hoistServerWithContext _ pc nt s =

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Swagger.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Swagger.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE BlockArguments #-}
 
 module Servant.Util.Combinators.Sorting.Swagger () where
 
@@ -7,27 +8,30 @@ import Universum
 import Control.Lens ((<>~), (?~))
 import qualified Data.Swagger as S
 import qualified Data.Text as T
+import Fmt (build, fmt, unlinesF)
 import Servant.API ((:>))
 import Servant.Swagger (HasSwagger (..))
 
 import Servant.Util.Combinators.Sorting.Base
 import Servant.Util.Common
 
-
-instance (HasSwagger api, ReifyParamsNames params) =>
-         HasSwagger (SortingParams params :> api) where
+instance (HasSwagger api, ReifySortingItems base, ReifyParamsNames provided) =>
+         HasSwagger (SortingParams provided base :> api) where
     toSwagger _ = toSwagger (Proxy @api)
         & S.allOperations . S.parameters <>~ [S.Inline param]
       where
         param = mempty
             & S.name .~ "sortBy"
-            & S.description ?~ T.unlines
+            & S.description ?~ fmt do
+              unlinesF
                 [ "Allows lexicographical sorting on fields."
                 , "General format is one of:"
                 , "  * `+field1,-field2`"
                 , "  * `asc(field1),desc(field2)`"
                 , ""
-                , " Fields allowed for this endpoint: " <> allowedFieldsDesc
+                , allowedFieldsDesc
+                , baseFieldsDesc
+                , " "
                 ]
             & S.required ?~ False
             & S.schema .~ S.ParamOther (mempty
@@ -40,7 +44,19 @@ instance (HasSwagger api, ReifyParamsNames params) =>
         fieldPattern =
             "(" <> "[+-](" <> allowedFieldsPattern <> ")+" <> "|" <>
             "(asc|desc)\\((" <> allowedFieldsPattern <> ")+\\))"
-        allowedFields = reifyParamsNames @params
-        allowedFieldsDesc =
-            T.intercalate ", " $ map ((<> "`") . ("`" <>)) (toList allowedFields)
-        allowedFieldsPattern = T.intercalate "|" (toList allowedFields)
+        allowedFields = reifyParamsNames @provided
+        allowedFieldsDesc = mconcat
+            [ " Fields allowed for this endpoint: "
+            , mconcat . intersperse ", " $
+                  map ((<> "`") . ("`" <>) . build) allowedFields
+            ]
+        allowedFieldsPattern = T.intercalate "|" allowedFields
+        baseFields = reifySortingItems @base
+        baseFieldsDesc
+            | null baseFields = ""
+            | otherwise = mconcat
+                [ " Base sorting (always applied, lexicographically last): "
+                , "`"
+                , mconcat . intersperse ", " $ map build baseFields
+                , "`"
+                ]

--- a/servant-util/src/Servant/Util/Dummy/Sorting.hs
+++ b/servant-util/src/Servant/Util/Dummy/Sorting.hs
@@ -65,8 +65,13 @@ instance SortingBackend DummySortingBackend where
 -- | Applies a whole filtering specification to a set of response fields.
 -- Resulting value can be put to 'filter' function.
 sortBySpec
-    :: (ApplyToSortItem backend params, backend ~ DummySortingBackend)
-    => SortingSpec params -> (a -> SortingSpecApp backend params) -> [a] -> [a]
+    :: ( backend ~ DummySortingBackend
+       , allParams ~ AllSortingParams provided base
+       , ApplyToSortItem backend allParams
+       )
+    => SortingSpec provided base
+    -> (a -> SortingSpecApp backend allParams)
+    -> [a] -> [a]
 sortBySpec spec mkApp values =
     map fst . sortOn snd $
     map (id &&& backendApplySorting spec . mkApp) values

--- a/servant-util/tests/Test/Servant/Helpers.hs
+++ b/servant-util/tests/Test/Servant/Helpers.hs
@@ -1,0 +1,69 @@
+module Test.Servant.Helpers
+    ( runTestServer
+    , runTestServerE
+    ) where
+
+import Universum
+
+import Control.Monad.Except (liftEither)
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.Wai.Handler.Warp (Port, testWithApplication)
+import Servant.API.Generic (GenericServant, ToServant, ToServantApi)
+import Servant.Client (BaseUrl (..), Client, ClientEnv, ClientError, ClientM, HasClient,
+                       Scheme (Http), mkClientEnv, runClientM)
+import Servant.Client.Generic (AsClientT, genericClientHoist)
+import Servant.Server (HasServer, Server)
+import Servant.Server.Generic (AsServer, genericServe)
+
+mkTestClientEnv :: Port -> IO ClientEnv
+mkTestClientEnv port = do
+  manager <- newManager defaultManagerSettings
+  let baseUrl = BaseUrl
+        { baseUrlScheme = Http
+        , baseUrlHost = "localhost"
+        , baseUrlPort = port
+        , baseUrlPath = ""
+        }
+  return $ mkClientEnv manager baseUrl
+
+-- | Runs server and returns client handlers to it.
+--
+-- This version returns client handlers where errors are returned
+-- explicitly.
+runTestServerE
+  :: ( GenericServant methods AsServer
+     , HasServer (ToServantApi methods) '[]
+     , Server (ToServantApi methods) ~ ToServant methods AsServer
+     , GenericServant methods (AsClientT (ExceptT ClientError IO))
+     , HasClient ClientM (ToServantApi methods)
+     , Client (ExceptT ClientError IO) (ToServantApi methods)
+         ~ ToServant methods (AsClientT (ExceptT ClientError IO))
+     )
+  => methods AsServer
+  -> (methods (AsClientT (ExceptT ClientError IO)) -> IO ())
+  -> IO ()
+runTestServerE handlers acceptClientHandlers =
+  testWithApplication (pure $ genericServe handlers) $ \port -> do
+    cliEnv <- mkTestClientEnv port
+    acceptClientHandlers $
+      genericClientHoist (lift . flip runClientM cliEnv >=> liftEither)
+
+-- | Runs server and returns client handlers to it.
+--
+-- In case a client handler fails, the exception will be propagated.
+runTestServer
+  :: ( GenericServant methods AsServer
+     , HasServer (ToServantApi methods) '[]
+     , Server (ToServantApi methods) ~ ToServant methods AsServer
+     , GenericServant methods (AsClientT IO)
+     , HasClient ClientM (ToServantApi methods)
+     , Client IO (ToServantApi methods) ~ ToServant methods (AsClientT IO)
+     )
+  => methods AsServer
+  -> (methods (AsClientT IO) -> IO ())
+  -> IO ()
+runTestServer handlers acceptClientHandlers =
+  testWithApplication (pure $ genericServe handlers) $ \port -> do
+    cliEnv <- mkTestClientEnv port
+    acceptClientHandlers $
+      genericClientHoist (flip runClientM cliEnv >=> either throwM pure)

--- a/servant-util/tests/Test/Servant/Sorting/ImplSpec.hs
+++ b/servant-util/tests/Test/Servant/Sorting/ImplSpec.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE OverloadedLists #-}
+
+module Test.Servant.Sorting.ImplSpec where
+
+import Universum
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.TH as Aeson
+import Data.Swagger (ToSchema)
+import Data.Time.Calendar.OrdinalDate (fromOrdinalDate)
+import Data.Time.Clock (UTCTime (..))
+import Servant.API (Get, JSON, (:>))
+import Servant.API.Generic (ToServantApi, (:-))
+import Servant.Server.Generic (AsServer)
+import Servant.Swagger (toSwagger)
+
+import Test.Hspec (Spec, aroundAll, describe, it)
+import Test.Hspec.Expectations (shouldBe)
+
+import Servant.Util
+import Servant.Util.Dummy
+
+import Test.Servant.Helpers
+
+-- Data model
+---------------------------------------------------------------------------
+
+newtype Isbn = Isbn Word64
+  deriving (Show, Eq, Ord, Generic)
+
+instance ToSchema Isbn
+
+Aeson.deriveJSON Aeson.defaultOptions ''Isbn
+
+data Book = Book
+  { isbn      :: Isbn
+  , name      :: Text
+  , rating    :: Word8
+  , createdAt :: UTCTime
+  } deriving (Show, Eq, Generic)
+
+instance ToSchema Book
+
+Aeson.deriveJSON Aeson.defaultOptions ''Book
+
+-- | Some strictly monotonic function from integers to time.
+toUTCTime :: Integer -> UTCTime
+toUTCTime idx = UTCTime (fromOrdinalDate idx 0) 0
+
+allBooks :: [Book]
+allBooks =
+  [ Book
+    { isbn = Isbn 111
+    , name = "How to cook tofu, the right way"
+    , rating = 5
+    , createdAt = toUTCTime 1
+    }
+
+  , Book
+    { isbn = Isbn 100
+    , name = "Delving into memes"
+    , rating = 5
+    , createdAt = toUTCTime 3
+    }
+
+  , Book
+    { isbn = Isbn 120
+    , name = "Book of something"
+    , rating = 4
+    , createdAt = toUTCTime 8
+    }
+
+  ]
+
+-- Server
+---------------------------------------------------------------------------
+
+data ApiMethods route = ApiMethods
+  { amSimpleSort
+      :: route
+      :- "simple"
+      :> SortingParams
+          [ "name" ?: Text
+          , "rating" ?: Word8
+          , "createdAt" ?: UTCTime
+          ]
+         '[ "isbn" ?: 'Asc Isbn
+          ]
+      :> Get '[JSON] [Book]
+
+  , amOverrideableSort
+      :: route
+      :- "overrideable"
+      :> SortingParams
+          [ "rating" ?: Word8
+          , "createdAt" ?: UTCTime
+          , "isbn" ?: Isbn
+          ]
+          [ "rating" ?: 'Desc Word8
+          , "isbn" ?: 'Asc Isbn
+          ]
+      :> Get '[JSON] [Book]
+
+  , amOverrideableSort2
+      :: route
+      :- "overrideable2"
+      :> SortingParams
+          [ "isbn" ?: Isbn
+          , "rating" ?: Word8
+          ]
+          [ "isbn" ?: 'Asc Isbn
+          , "rating" ?: 'Asc Word8
+          ]
+      :> Get '[JSON] [Book]
+
+  } deriving Generic
+
+apiHandlers :: ApiMethods AsServer
+apiHandlers = ApiMethods
+  { amSimpleSort = \sortingSpec -> do
+      let sortingApp Book{..} =
+            fieldSort @"name" name .*.
+            fieldSort @"rating" rating .*.
+            fieldSort @"createdAt" createdAt .*.
+            fieldSort @"isbn" isbn .*.
+            HNil
+      return $ sortBySpec sortingSpec sortingApp allBooks
+
+  , amOverrideableSort = \sortingSpec -> do
+      let sortingApp Book{..} =
+            fieldSort @"rating" rating .*.
+            fieldSort @"createdAt" createdAt .*.
+            fieldSort @"isbn" isbn .*.
+            fieldSort @"rating" rating .*.
+            fieldSort @"isbn" isbn .*.
+            HNil
+      return $ sortBySpec sortingSpec sortingApp allBooks
+
+  , amOverrideableSort2 = \sortingSpec -> do
+      let sortingApp Book{..} =
+            fieldSort @"isbn" isbn .*.
+            fieldSort @"rating" rating .*.
+            fieldSort @"isbn" isbn .*.
+            fieldSort @"rating" rating .*.
+            HNil
+      return $ sortBySpec sortingSpec sortingApp allBooks
+
+  }
+
+-- Swagger
+---------------------------------------------------------------------------
+
+-- You can try this with ghci
+printFilterSwagger :: IO ()
+printFilterSwagger =
+  writeFile "filter-test-swagger.json" $
+    decodeUtf8 . Aeson.encode $
+    toSwagger $ Proxy @(ToServantApi ApiMethods)
+
+-- Tests
+---------------------------------------------------------------------------
+
+spec :: Spec
+spec =
+  aroundAll (runTestServer apiHandlers) $ do
+
+    describe "Simple sort with base sorting" $ do
+
+      it "No sorting (sole base)" $
+        \ApiMethods{..} -> do
+          res <- amSimpleSort noSorting
+          map isbn res `shouldBe` [Isbn 100, Isbn 111, Isbn 120]
+
+      it "Fully determining sorting (base doesn't matter)" $
+        \ApiMethods{..} -> do
+          res <- amSimpleSort [asc #createdAt]
+          map isbn res `shouldBe` [Isbn 111, Isbn 100, Isbn 120]
+
+      it "Partially determining sorting (base matters)" $
+        \ApiMethods{..} -> do
+          res <- amSimpleSort [asc #rating]
+          map isbn res `shouldBe` [Isbn 120, Isbn 100, Isbn 111]
+
+    describe "Simple sort with overridable base sorting" $ do
+
+      it "No sorting (sole base)" $
+        \ApiMethods{..} -> do
+          res <- amOverrideableSort noSorting
+          map isbn res `shouldBe` [Isbn 100, Isbn 111, Isbn 120]
+
+      it "Base sorting can be overriden" $
+        \ApiMethods{..} -> do
+          res <- amOverrideableSort [desc #isbn]
+          map isbn res `shouldBe` [Isbn 120, Isbn 111, Isbn 100]
+
+      it "Overriden base sorting tolerates the provided sorting order" $
+        -- One possible bug is on @rating+,createdAt+@ request ignore @rating+@
+        -- since it is part of base sorting. But base sorting matters last, so
+        -- that wouldn't be valid.
+        \ApiMethods{..} -> do
+          res <- amOverrideableSort [asc #rating, asc #createdAt]
+          map isbn res `shouldBe` [Isbn 120, Isbn 111, Isbn 100]
+
+      it "Overriden field from base sorting doesn't cancel the remaining base sorting" $
+        \ApiMethods{..} -> do
+          res <- amOverrideableSort2 [asc #rating]
+          map isbn res `shouldBe` [Isbn 120, Isbn 100, Isbn 111]

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,7 @@ extra-deps:
 - dependent-sum-0.7.1.0
 - constraints-extras-0.3.0.2
 - network-uri-json-0.4.0.0
+- hspec-2.7.9
 
 allow-newer: true
 


### PR DESCRIPTION
## :white_check_mark: Checklist for your Pull Request

Adds base sorting that will be applied disregard the user-specified sorting.

This allows for deterministic results making pagination sane in all cases, even when sorting is not specified by the user.

Resolves #22.

- [ ] When some field is mentioned both in user-specified fields and in base sorting, how better to avoid duplication in implementation?

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [ ] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
