### PR TITLE
Do not use `autoexporter`

### DIFF
--- a/servant-util-beam-pg/package.yaml
+++ b/servant-util-beam-pg/package.yaml
@@ -20,9 +20,6 @@ dependencies:
 library:
   source-dirs: src
 
-  build-tools:
-    - autoexporter
-
 <<: *ghc-options
 
 executables:

--- a/servant-util-beam-pg/servant-util-beam-pg.cabal
+++ b/servant-util-beam-pg/servant-util-beam-pg.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6ef1c6ee74da17c3ee697b9d46aa6057bc4cb254cc1119be49523b207df91a35
+-- hash: 6dc1197e6121504741430e58f847d8e4248a712c21e73e45b694a5520cfa0e9c
 
 name:           servant-util-beam-pg
 version:        0.1.0.1
@@ -37,8 +37,6 @@ library
       src
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall
-  build-tool-depends:
-      autoexporter:autoexporter
   build-depends:
       base >=4.7 && <5
     , beam-core

--- a/servant-util-beam-pg/src/Servant/Util/Beam/Postgres.hs
+++ b/servant-util-beam-pg/src/Servant/Util/Beam/Postgres.hs
@@ -1,1 +1,7 @@
-{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}
+module Servant.Util.Beam.Postgres
+  ( module M
+  ) where
+
+import Servant.Util.Beam.Postgres.Filtering as M
+import Servant.Util.Beam.Postgres.Pagination as M
+import Servant.Util.Beam.Postgres.Sorting as M

--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -40,9 +40,6 @@ dependencies:
 library:
   source-dirs: src
 
-  build-tools:
-    - autoexporter
-
 <<: *ghc-options
 
 executables:

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: de73541e9d975e3ed0fdec0ca76af4a65ee45c1ba3e85c9dde8b9b02b103cac4
+-- hash: f8f98d17af973304515c0305889a12f2f94d992dd126b9dbbb5adc8bc7767cdc
 
 name:           servant-util
 version:        0.1.0.1
@@ -75,8 +75,6 @@ library
       src
   default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
   ghc-options: -Wall
-  build-tool-depends:
-      autoexporter:autoexporter
   build-depends:
       QuickCheck
     , aeson

--- a/servant-util/src/Servant/Util/Combinators.hs
+++ b/servant-util/src/Servant/Util/Combinators.hs
@@ -1,1 +1,10 @@
-{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}
+module Servant.Util.Combinators
+  ( module M
+  ) where
+
+import Servant.Util.Combinators.ErrorResponses as M
+import Servant.Util.Combinators.Filtering as M
+import Servant.Util.Combinators.Logging as M
+import Servant.Util.Combinators.Pagination as M
+import Servant.Util.Combinators.Sorting as M
+import Servant.Util.Combinators.Tag as M

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Filters.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Filters.hs
@@ -1,2 +1,7 @@
 -- | Various filter types.
-{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}
+module Servant.Util.Combinators.Filtering.Filters
+  ( module M
+  ) where
+
+import Servant.Util.Combinators.Filtering.Filters.General as M
+import Servant.Util.Combinators.Filtering.Filters.Like as M

--- a/servant-util/src/Servant/Util/Common.hs
+++ b/servant-util/src/Servant/Util/Common.hs
@@ -1,1 +1,7 @@
-{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}
+module Servant.Util.Common
+  ( module M
+  ) where
+
+import Servant.Util.Common.Common as M
+import Servant.Util.Common.HList as M
+import Servant.Util.Common.PolyKinds as M

--- a/servant-util/src/Servant/Util/Dummy.hs
+++ b/servant-util/src/Servant/Util/Dummy.hs
@@ -1,2 +1,9 @@
 -- | Contains dummy backend implementations for introduced combinators.
-{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}
+
+module Servant.Util.Dummy
+  ( module M
+  ) where
+
+import Servant.Util.Dummy.Filtering as M
+import Servant.Util.Dummy.Pagination as M
+import Servant.Util.Dummy.Sorting as M


### PR DESCRIPTION
Problem: at this moment, we want the package to be located on Hackage,
but it still fails to render documentation for packages using any build
tools, see the
[issue](https://github.com/haskell/hackage-server/issues/821).

Moreover, my HLS fails to build the project because of autoexporter as
well.

Solution: replace uses of `autoexporter` with manually written module
lists.

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
