### PR TITLE
Add servant 0.19 support to servant-util

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  ./servant-util
+  ./servant-util-beam-pg

--- a/servant-util/CHANGES.md
+++ b/servant-util/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 =====
 
+* Added support for building the project with `servant` version >= 0.19.
+
 0.3
 ===
 

--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -9,6 +9,7 @@ category:            Servant, Web
 dependencies:
 - aeson
 - base >= 4.7 && < 5
+- bytestring
 - constraints
 - containers
 - data-default

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f0ae0577e7cde4002a074bd5fada6d918ea3dc45baee134d38fa8e002ad66d9f
+-- hash: 16c019b25a3f668898f483828ea8a0de802a4155bb4601f08b6fe4e095358e04
 
 name:           servant-util
 version:        0.3
@@ -188,6 +188,7 @@ executable servant-util-examples
       QuickCheck
     , aeson
     , base >=4.7 && <5
+    , bytestring
     , constraints
     , containers
     , data-default
@@ -276,6 +277,7 @@ test-suite servant-util-test
       QuickCheck
     , aeson
     , base >=4.7 && <5
+    , bytestring
     , constraints
     , containers
     , data-default

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -111,6 +111,7 @@ library
       QuickCheck
     , aeson
     , base >=4.7 && <5
+    , bytestring
     , constraints
     , containers
     , data-default

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
@@ -16,7 +16,12 @@ import Servant.Util.Combinators.Filtering.Support ()
 import Servant.Util.Common
 
 #if MIN_VERSION_servant(0,19,0)
-import qualified Data.Text.Encoding as T
+import Data.ByteString (ByteString)
+import Data.ByteString.Builder (toLazyByteString)
+import qualified Data.ByteString.Lazy as BL
+
+encodeQueryParam :: ToHttpApiData a => a  -> ByteString
+encodeQueryParam = BL.toStrict . toLazyByteString . toEncodedUrlPiece
 #endif
 
 -------------------------------------------------------------------------
@@ -47,7 +52,7 @@ instance ( KnownSymbol name
         | symbolValT @name == sfName =
             let filter :: TypeFilter fk a = cast sfFilter ?: error "Failed to cast filter"
 #if MIN_VERSION_servant(0,19,0)
-                (op, value) = T.encodeUtf8 <$> typeFilterToReq filter
+                (op, value) = encodeQueryParam <$> typeFilterToReq filter
 #else
                 (op, value) = typeFilterToReq filter
 #endif

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Client.hs
@@ -16,7 +16,6 @@ import Servant.Util.Combinators.Filtering.Support ()
 import Servant.Util.Common
 
 #if MIN_VERSION_servant(0,19,0)
-import Data.ByteString (ByteString)
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as BL
 

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Filters/General.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Filters/General.hs
@@ -10,7 +10,7 @@ import Universum
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Fmt (build, listF)
-import Servant (FromHttpApiData (..), ToHttpApiData (..))
+import Servant (FromHttpApiData (..))
 
 import Servant.Util.Combinators.Filtering.Base
 
@@ -57,10 +57,12 @@ instance IsAutoFilter FilterMatching where
             mapM parseUrlPiece vals
 
     autoFilterEncode = \case
-        FilterMatching v    -> (DefFilteringCmd, toQueryParam v)
-        FilterNotMatching v -> ("neq", toQueryParam v)
-        FilterItemsIn vs    -> ("in", "[" <> T.intercalate "," (map toQueryParam vs) <> "]")
-
+        FilterMatching v    -> (DefFilteringCmd, encodeQueryParam v)
+        FilterNotMatching v -> ("neq", encodeQueryParam v)
+        FilterItemsIn vs    -> ("in", encodeFilterItems vs)
+      where
+        encodeFilterItems vs =
+            "[" <> mconcat (intersperse "," $ map encodeQueryParam vs) <> "]"
 
 -- | Support for @(<)@, @(>)@, @(<=)@ and @(>=)@ operations.
 data FilterComparing a
@@ -101,10 +103,10 @@ instance IsAutoFilter FilterComparing where
         ]
 
     autoFilterEncode = \case
-        FilterGT v  -> ("gt", toQueryParam v)
-        FilterLT v  -> ("lt", toQueryParam v)
-        FilterGTE v -> ("gte", toQueryParam v)
-        FilterLTE v -> ("lte", toQueryParam v)
+        FilterGT v  -> ("gt", encodeQueryParam v)
+        FilterLT v  -> ("lt", encodeQueryParam v)
+        FilterGTE v -> ("gte", encodeQueryParam v)
+        FilterLTE v -> ("lte", encodeQueryParam v)
 
 
 -------------------------------------------------------------------------

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Filters/Like.hs
@@ -15,7 +15,7 @@ import Universum
 import qualified Data.Map as M
 import qualified Data.Text.Lazy as LT
 import Fmt (Buildable (..), (+|), (|+))
-import Servant (FromHttpApiData (..), ToHttpApiData (..))
+import Servant (FromHttpApiData (..))
 import System.Console.Pretty (Color (..), Style (..), color, style)
 
 import Servant.Util.Combinators.Filtering.Base
@@ -117,6 +117,6 @@ instance IsAutoFilter FilterLike where
     autoFilterEncode = \case
         FilterLike cs (unLikePattern -> pat)
             | CaseSensitivity True <- cs
-                -> ("like", toQueryParam pat)
+                -> ("like", encodeQueryParam pat)
             | otherwise
-                -> ("ilike", toQueryParam pat)
+                -> ("ilike", encodeQueryParam pat)

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Construction.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Construction.hs
@@ -11,7 +11,8 @@ module Servant.Util.Combinators.Sorting.Construction
 import Universum
 
 import Data.Default (Default (..))
-import GHC.Exts (IsList (..))
+import qualified GHC.Exts
+import GHC.Exts (IsList)
 import GHC.TypeLits (ErrorMessage (..), KnownSymbol, Symbol, TypeError)
 
 import Servant.Util.Combinators.Sorting.Base
@@ -79,7 +80,7 @@ sortingSpec = mkSortingSpec [asc #id]
 mkSortingSpec
     :: ReifySortingItems base
     => [SortingRequestItem provided] -> SortingSpec provided base
-mkSortingSpec = fromList
+mkSortingSpec = GHC.Exts.fromList
 
 -- | By default 'noSorting' is used.
 instance ReifySortingItems base => Default (SortingSpec provided base) where


### PR DESCRIPTION
This PR proposes to:
- Add support to build with `servant` >= v0.19 (fix https://github.com/serokell/servant-util/issues/38)
- Add `cabal.project` file
- Fix building with `universum-1.7.3`

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [ ] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [ ] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [ ] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [ ] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
