### PR TITLE
Replace `mapAutoFilterValue` with `Functor`

### DIFF
--- a/servant-util/CHANGES.md
+++ b/servant-util/CHANGES.md
@@ -1,6 +1,7 @@
 Unreleased
 =====
 
+* Replaced `mapAutoFilterValue` in `IsAutoFilter` typeclass with `Functor` superclass.
 * Exposed `MkSomeFilter` constraint.
 * Added support for building the project with `servant` version >= 0.19.
 

--- a/servant-util/src/Servant/Util/Combinators/Filtering/Base.hs
+++ b/servant-util/src/Servant/Util/Combinators/Filtering/Base.hs
@@ -115,7 +115,7 @@ class BuildableAutoFilter (filter :: Type -> Type) where
         :: Buildable a => Text -> filter a -> Builder
 
 -- | Application of a filter type to Servant API.
-class (Typeable filter, BuildableAutoFilter filter) =>
+class (Typeable filter, Functor filter, BuildableAutoFilter filter) =>
       IsAutoFilter (filter :: Type -> Type) where
 
     -- | For each supported filtering operation specifies a short plain-english
@@ -132,12 +132,6 @@ class (Typeable filter, BuildableAutoFilter filter) =>
     autoFilterEncode
         :: ToHttpApiData a
         => filter a -> (Text, EncodedQueryParam)
-
-    mapAutoFilterValue
-        :: (a -> b) -> filter a -> filter b
-    default mapAutoFilterValue
-        :: Functor filter => (a -> b) -> filter a -> filter b
-    mapAutoFilterValue = fmap
 
 -- | Multi-version of 'IsFilter'.
 class AreAutoFilters (filters :: [Type -> Type]) where
@@ -171,7 +165,7 @@ data SomeTypeAutoFilter a =
     forall filter. IsAutoFilter filter => SomeTypeAutoFilter (filter a)
 
 instance Functor SomeTypeAutoFilter where
-    fmap f (SomeTypeAutoFilter filtr) = SomeTypeAutoFilter (mapAutoFilterValue f filtr)
+    fmap f (SomeTypeAutoFilter filtr) = SomeTypeAutoFilter (fmap f filtr)
 
 instance Buildable a => Buildable (Text, SomeTypeAutoFilter a) where
     build (name, SomeTypeAutoFilter f) = buildAutoFilter name f


### PR DESCRIPTION
Problem: `mapAutoFilterValue` is semantically equivalent to `fmap`,
however it is not documented.

Solution: replace it with `Functor` superclass.

Resolves #39.

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [ ] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [ ] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [ ] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [ ] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
