### PR TITLE
Get rid of `text-format` dependency

### DIFF
--- a/servant-util/package.yaml
+++ b/servant-util/package.yaml
@@ -32,7 +32,6 @@ dependencies:
 - servant-swagger-ui-core
 - swagger2
 - text
-- text-format
 - time
 - reflection
 - regex-posix

--- a/servant-util/servant-util.cabal
+++ b/servant-util/servant-util.cabal
@@ -134,7 +134,6 @@ library
     , servant-swagger-ui-core
     , swagger2
     , text
-    , text-format
     , time
     , universum
     , wai
@@ -212,7 +211,6 @@ executable servant-util-examples
     , servant-util
     , swagger2
     , text
-    , text-format
     , time
     , universum
     , wai
@@ -304,7 +302,6 @@ test-suite servant-util-test
     , servant-util
     , swagger2
     , text
-    , text-format
     , time
     , universum
     , wai

--- a/servant-util/src/Servant/Util/Common/Common.hs
+++ b/servant-util/src/Servant/Util/Common/Common.hs
@@ -12,8 +12,7 @@ module Servant.Util.Common.Common
 
 import Universum
 
-import qualified Data.Text.Buildable as B
-import Fmt (pretty)
+import Fmt (build, pretty)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Servant.API (Capture, QueryFlag, QueryParam', ReqBody, (:>))
 import Servant.API.Modifiers (RequiredArgument)
@@ -42,7 +41,7 @@ class ApiHasArgClass api where
         :: forall n someApiType a. (KnownSymbol n, api ~ someApiType n a)
         => Proxy api -> String
     apiArgName _ =
-        pretty $ "'" <> B.build (symbolVal $ Proxy @n) <> "' field"
+        pretty $ "'" <> build (symbolVal $ Proxy @n) <> "' field"
 
 class ServerT (subApi :> res) m ~ (ApiArg subApi -> ServerT res m)
    => ApiHasArgInvariant subApi res m
@@ -60,7 +59,7 @@ instance KnownSymbol s => ApiHasArgClass (QueryParam' mods s a) where
 instance KnownSymbol s => ApiHasArgClass (QueryFlag s) where
     type ApiArg (QueryFlag s) = Bool
     apiArgName _ =
-        pretty $ "'" <> B.build (symbolVal (Proxy @s)) <>  "' flag"
+        pretty $ "'" <> build (symbolVal (Proxy @s)) <>  "' flag"
 instance ApiHasArgClass (ReqBody ct a) where
     apiArgName _ = "request body"
 


### PR DESCRIPTION
This dependency was not actually necessary nowadays.

## :white_check_mark: Checklist for your Pull Request

Resolves #48 

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [ ] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [ ] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [ ] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.
