### PR TITLE
[#53] Allow non-alphanumeric characters in sorting keys

### DIFF
--- a/servant-util/CHANGES.md
+++ b/servant-util/CHANGES.md
@@ -4,6 +4,7 @@ Unreleased
 * Replaced `mapAutoFilterValue` in `IsAutoFilter` typeclass with `Functor` superclass.
 * Exposed `MkSomeFilter` constraint.
 * Added support for building the project with `servant` version >= 0.19.
+* Relax the parser of sorting keys to allow for non-alphanumeric identifier formats, like snake_case.
 
 0.3
 ===

--- a/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
+++ b/servant-util/src/Servant/Util/Combinators/Sorting/Server.hs
@@ -4,7 +4,6 @@ module Servant.Util.Combinators.Sorting.Server () where
 
 import Universum
 
-import Data.Char (isAlphaNum)
 import qualified Data.List as L
 import qualified Data.Set as S
 import Servant.API (FromHttpApiData (..), (:>))
@@ -79,7 +78,10 @@ instance ReifyParamsNames allowed =>
         allowedParams = reifyParamsNamesSet @allowed
 
         paramNameParser = do
-            name <- P.takeWhile1P (Just "sorting item name") isAlphaNum <?> "parameter name"
+            -- The exlusion of `,` and `)` happens because 'paramNameParser' is called within 'itemParser',
+            -- which itself does the exlusion of ')'. Since it hasn't happened yet, we need to be mindful of
+            -- closing parens.
+            name <- P.takeWhile1P (Just "sorting item name") (\c -> c /= ',' && c /= ')') <?> "parameter name"
             unless (name `S.member` allowedParams) $
                 fail $ "unknown parameter " <> show name <>
                        " (expected one of " <> show (toList allowedParams) <> ")"

--- a/servant-util/tests/Test/Servant/Sorting/ImplSpec.hs
+++ b/servant-util/tests/Test/Servant/Sorting/ImplSpec.hs
@@ -82,7 +82,7 @@ data ApiMethods route = ApiMethods
       :> SortingParams
           [ "name" ?: Text
           , "rating" ?: Word8
-          , "createdAt" ?: UTCTime
+          , "created_at" ?: UTCTime
           ]
          '[ "isbn" ?: 'Asc Isbn
           ]
@@ -93,7 +93,7 @@ data ApiMethods route = ApiMethods
       :- "overrideable"
       :> SortingParams
           [ "rating" ?: Word8
-          , "createdAt" ?: UTCTime
+          , "created_at" ?: UTCTime
           , "isbn" ?: Isbn
           ]
           [ "rating" ?: 'Desc Word8
@@ -121,7 +121,7 @@ apiHandlers = ApiMethods
       let sortingApp Book{..} =
             fieldSort @"name" name .*.
             fieldSort @"rating" rating .*.
-            fieldSort @"createdAt" createdAt .*.
+            fieldSort @"created_at" createdAt .*.
             fieldSort @"isbn" isbn .*.
             HNil
       return $ sortBySpec sortingSpec sortingApp allBooks
@@ -129,7 +129,7 @@ apiHandlers = ApiMethods
   , amOverrideableSort = \sortingSpec -> do
       let sortingApp Book{..} =
             fieldSort @"rating" rating .*.
-            fieldSort @"createdAt" createdAt .*.
+            fieldSort @"created_at" createdAt .*.
             fieldSort @"isbn" isbn .*.
             fieldSort @"rating" rating .*.
             fieldSort @"isbn" isbn .*.
@@ -173,7 +173,7 @@ spec =
 
       it "Fully determining sorting (base doesn't matter)" $
         \ApiMethods{..} -> do
-          res <- amSimpleSort [asc #createdAt]
+          res <- amSimpleSort [asc #created_at]
           map isbn res `shouldBe` [Isbn 111, Isbn 100, Isbn 120]
 
       it "Partially determining sorting (base matters)" $
@@ -198,7 +198,7 @@ spec =
         -- since it is part of base sorting. But base sorting matters last, so
         -- that wouldn't be valid.
         \ApiMethods{..} -> do
-          res <- amOverrideableSort [asc #rating, asc #createdAt]
+          res <- amOverrideableSort [asc #rating, asc #created_at]
           map isbn res `shouldBe` [Isbn 120, Isbn 111, Isbn 100]
 
       it "Overriden field from base sorting doesn't cancel the remaining base sorting" $


### PR DESCRIPTION
This especially allows for snake_case identifiers to be valid sorting keys. 


## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- [x] Tests
  - If I added new functionality, I added tests covering it.
  - If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- [x] Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [README](/README.md);
    - Haddock;
    - [Examples](/examples/).

- [x] Public contracts
  - Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - provided a migration guide for breaking changes if possible.

#### Stylistic guide (mandatory)

- [x] Style
  - My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
  - My code complies with the [style guide](../tree/master/docs/code-style.md).
  - Each commit of this pull request contains a description.
    - For new features, this description contains the use case for the new functionality.
    - For bug fixes, it describes both the attacked problem and a solution for it.
    - For dependency version changes description shortly enlists features and breaking changes of the new library version or contains a link to its changelog.

Fix #53

Sponsored-by: Scrive AB
